### PR TITLE
Add a slight improvement to the loading speed of the language selection dropdown

### DIFF
--- a/src/ResXManager.View/Visuals/LanguageSelectionBoxView.xaml
+++ b/src/ResXManager.View/Visuals/LanguageSelectionBoxView.xaml
@@ -14,7 +14,7 @@
     <TextBlock Text="{x:Static properties:Resources.NewLanguageIdPrompt}" TextWrapping="Wrap" />
     <Decorator Height="10" />
     <ComboBox x:Name="ComboBox" IsEditable="True"
-              ItemsSource="{Binding Languages}"
+              ItemsSource="{Binding Languages, Mode=OneTime}"
               HorizontalAlignment="Stretch"
               SelectedItem="{Binding SelectedLanguage, ValidatesOnDataErrors=True, UpdateSourceTrigger=PropertyChanged}"
               Style="{DynamicResource {x:Static styles:ResourceKeys.ComboBoxStyle}}">


### PR DESCRIPTION
Adds a minor speed improvement to clicking the dropdown subsequent times. The values should be the same since the .Except() is only run once in the constructor.