### PR TITLE
395_Escape_diacritics_characters

### DIFF
--- a/src/ResXManager.VSIX/ResXManager.VSIX.csproj
+++ b/src/ResXManager.VSIX/ResXManager.VSIX.csproj
@@ -268,6 +268,9 @@
     <PackageReference Include="DataGridExtensions">
       <Version>2.4.7</Version>
     </PackageReference>
+    <PackageReference Include="Diacritics">
+      <Version>2.1.20036.1</Version>
+    </PackageReference>
     <PackageReference Include="Fody" PrivateAssets="all">
       <Version>6.3.0</Version>
     </PackageReference>

--- a/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
+++ b/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
@@ -9,7 +9,7 @@
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Text;
-
+    using Diacritics.Extensions;
     using EnvDTE;
 
     using PropertyChanged;
@@ -181,16 +181,21 @@
 
             var makeUpper = true;
 
-            foreach (var c in text)
+            if (!string.IsNullOrEmpty(text))
             {
-                if (!IsCharValidForSymbol(c))
+                var textNonDiacritics = text?.RemoveDiacritics();
+
+                foreach (var c in textNonDiacritics)
                 {
-                    makeUpper = true;
-                }
-                else
-                {
-                    keyBuilder.Append(makeUpper ? char.ToUpper(c, CultureInfo.CurrentCulture) : c);
-                    makeUpper = false;
+                    if (!IsCharValidForSymbol(c))
+                    {
+                        makeUpper = true;
+                    }
+                    else
+                    {
+                        keyBuilder.Append(makeUpper ? char.ToUpper(c, CultureInfo.CurrentCulture) : c);
+                        makeUpper = false;
+                    }
                 }
             }
 

--- a/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
+++ b/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
@@ -181,21 +181,18 @@
 
             var makeUpper = true;
 
-            if (!string.IsNullOrEmpty(text))
-            {
-                var textNonDiacritics = text?.RemoveDiacritics();
+            var textNonDiacritics = text.RemoveDiacritics();
 
-                foreach (var c in textNonDiacritics)
+            foreach (var c in textNonDiacritics)
+            {
+                if (!IsCharValidForSymbol(c))
                 {
-                    if (!IsCharValidForSymbol(c))
-                    {
-                        makeUpper = true;
-                    }
-                    else
-                    {
-                        keyBuilder.Append(makeUpper ? char.ToUpper(c, CultureInfo.CurrentCulture) : c);
-                        makeUpper = false;
-                    }
+                    makeUpper = true;
+                }
+                else
+                {
+                    keyBuilder.Append(makeUpper ? char.ToUpper(c, CultureInfo.CurrentCulture) : c);
+                    makeUpper = false;
                 }
             }
 


### PR DESCRIPTION
Related issue: https://github.com/dotnet/ResXResourceManager/issues/395

At the moment it throws the following exception:
```
Could not load file or assembly 'Diacritics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. A strongly-named assembly is required. (Exception from HRESULT: 0x80131044)
```

Maybe someone can help me with that.