### PR TITLE
Persist settings after updates

### DIFF
--- a/src/ResXManager.Infrastructure/ExtensionMethods.cs
+++ b/src/ResXManager.Infrastructure/ExtensionMethods.cs
@@ -106,5 +106,16 @@
                 }
             }
         }
+
+        /// <summary>
+        /// Migrate app settings if needed (after upgrade of VS or a new build of the standalone app).
+        /// </summary>
+        /// <param name="settings"></param>
+        public static void MigrateSettings(this System.Configuration.ApplicationSettingsBase settings)
+        {
+            settings.Upgrade();
+            settings.Save();
+            settings.Reload();
+        }
     }
 }

--- a/src/ResXManager.Translators/Properties/Settings.Designer.cs
+++ b/src/ResXManager.Translators/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ResXManager.Translators.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -32,6 +32,18 @@ namespace ResXManager.Translators.Properties {
             }
             set {
                 this["Configuration"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool upgradeNeeded {
+            get {
+                return ((bool)(this["upgradeNeeded"]));
+            }
+            set {
+                this["upgradeNeeded"] = value;
             }
         }
     }

--- a/src/ResXManager.Translators/Properties/Settings.settings
+++ b/src/ResXManager.Translators/Properties/Settings.settings
@@ -1,9 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="tomenglertde.ResXManager.Translators.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="ResXManager.Translators.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
     <Setting Name="Configuration" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="upgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResXManager.Translators/Properties/Settings.settings
+++ b/src/ResXManager.Translators/Properties/Settings.settings
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="ResXManager.Translators.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="tomenglertde.ResXManager.Translators.Properties" GeneratedClassName="Settings">
   <Profiles />
   <Settings>
     <Setting Name="Configuration" Type="System.String" Scope="User">

--- a/src/ResXManager.Translators/TranslatorHost.cs
+++ b/src/ResXManager.Translators/TranslatorHost.cs
@@ -29,6 +29,16 @@
             _translators = translators;
 
             var settings = Settings.Default;
+
+            if (settings.upgradeNeeded)
+            {
+                settings.Upgrade();
+                settings.Save();
+                settings.Reload();
+                settings.upgradeNeeded = false;
+                settings.Save();
+            }
+
             var configuration = settings.Configuration;
 
             LoadConfiguration(translators, configuration);

--- a/src/ResXManager.Translators/TranslatorHost.cs
+++ b/src/ResXManager.Translators/TranslatorHost.cs
@@ -32,11 +32,8 @@
 
             if (settings.upgradeNeeded)
             {
-                settings.Upgrade();
-                settings.Save();
-                settings.Reload();
+                settings.MigrateSettings();
                 settings.upgradeNeeded = false;
-                settings.Save();
             }
 
             var configuration = settings.Configuration;

--- a/src/ResXManager.VSIX/Properties/Settings.Designer.cs
+++ b/src/ResXManager.VSIX/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ResXManager.VSIX.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,18 @@ namespace ResXManager.VSIX.Properties {
             }
             set {
                 this["MoveToResourcePreferedKeyPatterns"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool upgradeNeeded {
+            get {
+                return ((bool)(this["upgradeNeeded"]));
+            }
+            set {
+                this["upgradeNeeded"] = value;
             }
         }
     }

--- a/src/ResXManager.VSIX/Properties/Settings.settings
+++ b/src/ResXManager.VSIX/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="MoveToResourcePreferedKeyPatterns" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="upgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResXManager.VSIX/Visuals/MoveToResourceView.xaml.cs
+++ b/src/ResXManager.VSIX/Visuals/MoveToResourceView.xaml.cs
@@ -23,11 +23,8 @@
                 var settings = Properties.Settings.Default;
                 if (settings.upgradeNeeded)
                 {
-                    settings.Upgrade();
-                    settings.Save();
-                    settings.Reload();
+                    settings.MigrateSettings();
                     settings.upgradeNeeded = false;
-                    settings.Save();
                 }
 
                 this.SetExportProvider(exportProvider);

--- a/src/ResXManager.VSIX/Visuals/MoveToResourceView.xaml.cs
+++ b/src/ResXManager.VSIX/Visuals/MoveToResourceView.xaml.cs
@@ -20,6 +20,16 @@
         {
             try
             {
+                var settings = Properties.Settings.Default;
+                if (settings.upgradeNeeded)
+                {
+                    settings.Upgrade();
+                    settings.Save();
+                    settings.Reload();
+                    settings.upgradeNeeded = false;
+                    settings.Save();
+                }
+
                 this.SetExportProvider(exportProvider);
 
                 InitializeComponent();

--- a/src/ResXManager.VSIX/app.config
+++ b/src/ResXManager.VSIX/app.config
@@ -22,6 +22,9 @@
       <setting name="MoveToResourcePreferedKeyPatterns" serializeAs="String">
         <value />
       </setting>
+      <setting name="upgradeNeeded" serializeAs="String">
+          <value>True</value>
+      </setting>
     </tomenglertde.ResXManager.VSIX.Properties.Settings>
   </userSettings>
   <runtime>

--- a/src/ResXManager.View/Properties/Settings.Designer.cs
+++ b/src/ResXManager.View/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ResXManager.View.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -128,6 +128,18 @@ namespace ResXManager.View.Properties {
             }
             set {
                 this["IsOpenSourceMessageConfirmed"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool upgradeNeeded {
+            get {
+                return ((bool)(this["upgradeNeeded"]));
+            }
+            set {
+                this["upgradeNeeded"] = value;
             }
         }
     }

--- a/src/ResXManager.View/Properties/Settings.settings
+++ b/src/ResXManager.View/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="IsOpenSourceMessageConfirmed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="upgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResXManager.View/Visuals/ResourceView.xaml.cs
+++ b/src/ResXManager.View/Visuals/ResourceView.xaml.cs
@@ -45,6 +45,16 @@
 
             try
             {
+                var settings = Properties.Settings.Default;
+                if (settings.upgradeNeeded)
+                {
+                    settings.Upgrade();
+                    settings.Save();
+                    settings.Reload();
+                    settings.upgradeNeeded = false;
+                    settings.Save();
+                }
+
                 this.SetExportProvider(exportProvider);
 
                 _resourceManager.Loaded += ResourceManager_Loaded;

--- a/src/ResXManager.View/Visuals/ResourceView.xaml.cs
+++ b/src/ResXManager.View/Visuals/ResourceView.xaml.cs
@@ -48,11 +48,8 @@
                 var settings = Properties.Settings.Default;
                 if (settings.upgradeNeeded)
                 {
-                    settings.Upgrade();
-                    settings.Save();
-                    settings.Reload();
+                    settings.MigrateSettings();
                     settings.upgradeNeeded = false;
-                    settings.Save();
                 }
 
                 this.SetExportProvider(exportProvider);

--- a/src/ResXManager/MainViewModel.cs
+++ b/src/ResXManager/MainViewModel.cs
@@ -44,7 +44,18 @@
 
             try
             {
-                var folder = Settings.Default.StartupFolder;
+                var settings = Settings.Default;
+
+                if (settings.upgradeNeeded)
+                {
+                    settings.Upgrade();
+                    settings.Save();
+                    settings.Reload();
+                    settings.upgradeNeeded = false;
+                    settings.Save();
+                }
+
+                var folder = settings.StartupFolder;
 
                 if (folder.IsNullOrEmpty())
                     return;

--- a/src/ResXManager/MainViewModel.cs
+++ b/src/ResXManager/MainViewModel.cs
@@ -48,11 +48,8 @@
 
                 if (settings.upgradeNeeded)
                 {
-                    settings.Upgrade();
-                    settings.Save();
-                    settings.Reload();
+                    settings.MigrateSettings();
                     settings.upgradeNeeded = false;
-                    settings.Save();
                 }
 
                 var folder = settings.StartupFolder;

--- a/src/ResXManager/MainWindow.xaml.cs
+++ b/src/ResXManager/MainWindow.xaml.cs
@@ -111,6 +111,7 @@
 
             Settings.StartupLocation = _lastKnownLocation;
             Settings.StartupSize = _lastKnownSize;
+            Settings.Save();
         }
 
         private static Settings Settings => Settings.Default;

--- a/src/ResXManager/MainWindow.xaml.cs
+++ b/src/ResXManager/MainWindow.xaml.cs
@@ -111,7 +111,6 @@
 
             Settings.StartupLocation = _lastKnownLocation;
             Settings.StartupSize = _lastKnownSize;
-            Settings.Save();
         }
 
         private static Settings Settings => Settings.Default;

--- a/src/ResXManager/Properties/Settings.Designer.cs
+++ b/src/ResXManager/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ResXManager.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -56,6 +56,18 @@ namespace ResXManager.Properties {
             }
             set {
                 this["StartupLocation"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool upgradeNeeded {
+            get {
+                return ((bool)(this["upgradeNeeded"]));
+            }
+            set {
+                this["upgradeNeeded"] = value;
             }
         }
     }

--- a/src/ResXManager/Properties/Settings.settings
+++ b/src/ResXManager/Properties/Settings.settings
@@ -11,5 +11,8 @@
     <Setting Name="StartupLocation" Type="System.Windows.Vector" Scope="User">
       <Value Profile="(Default)">50,50</Value>
     </Setting>
+    <Setting Name="upgradeNeeded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/ResXManager/app.config
+++ b/src/ResXManager/app.config
@@ -16,6 +16,9 @@
       <setting name="StartupLocation" serializeAs="String">
         <value>50,50</value>
       </setting>
+      <setting name="upgradeNeeded" serializeAs="String">
+        <value>True</value>
+      </setting>
     </tomenglertde.ResXManager.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
Fixes #441. 

See issue for details. 

VS automatically changed the "GeneratedClassNamespace" attribute in `Settings.Settings` - I don't think this will cause any side effects so I left it as is. 