### PR TITLE
Preselect resource entity on "Move to Resource"

### DIFF
--- a/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
+++ b/src/ResXManager.VSIX/Visuals/MoveToResourceViewModel.cs
@@ -26,7 +26,9 @@
         public MoveToResourceViewModel(IVsixCompatibility vsixCompatibility, ICollection<string> patterns, ICollection<ResourceEntity> resourceEntities, string text, string extension, string? className, string? functionName, string? fileName)
         {
             ResourceEntities = resourceEntities;
-            SelectedResourceEntity = resourceEntities.FirstOrDefault();
+            SelectedResourceEntity = resourceEntities
+                .FirstOrDefault(x => (fileName ?? string.Empty).StartsWith(x.BaseName, StringComparison.OrdinalIgnoreCase))
+                ?? resourceEntities.FirstOrDefault();
 
             ExistingEntries = resourceEntities
                 .SelectMany(entity => entity.Entries)


### PR DESCRIPTION
This simple PR adds preselection of the corresponding resource entity when the "Move to Resource" dialog is openend.

![devenv_2022-06-02_15-15-10](https://user-images.githubusercontent.com/30472657/171637609-cc0323c5-a35a-45f8-bd0f-d885390e4afa.gif)

In my Blazor Server project where `IStringLocalizer` is used, every page and component (about 100 in total, once finished) has a corresponding resource file. Before this PR, there was simply the first resource file selected and the devoloper adding a translation had to find and select the correct resource entity manually. This was time consuming and error prone.

Now, based on the file name where the string is located in, the correct resource entity with the same name is preselected and "OK" can be clicked immediately whithout selecting the resource manually.