### PR TITLE
# Fix  BaiduTranslator.cs Serializedsecretkey is null when saving credentials is not selected

### DIFF
--- a/src/ResXManager.Translators/BaiduTranslator.cs
+++ b/src/ResXManager.Translators/BaiduTranslator.cs
@@ -114,11 +114,11 @@
 
                     if (Domain.IsNullOrWhiteSpace())
                     {
-                        sign = EncryptString(AppId + q + salt + SerializedSecretKey);
+                        sign = EncryptString(AppId + q + salt + SecretKey);
                     }
                     else
                     {
-                        sign = EncryptString(AppId + q + salt + Domain + SerializedSecretKey);
+                        sign = EncryptString(AppId + q + salt + Domain + SecretKey);
                         parameters.AddRange(new[] { "domain", Domain });
                     }
                     parameters.AddRange(new[]


### PR DESCRIPTION
Hello! I'm sorry!

Serializedsecretkey is null when saving credentials is not selected