### PR TITLE
Automatically create missing resource files on import

### DIFF
--- a/src/ResXManager.View/Visuals/ResourceViewModel.cs
+++ b/src/ResXManager.View/Visuals/ResourceViewModel.cs
@@ -470,8 +470,10 @@
                 return;
 
             var changes = ResourceManager.ImportExcelFile(fileName);
-
             changes.Apply();
+
+            if (ResourceManager.Configuration.Scope == ConfigurationScope.Global && !string.IsNullOrEmpty(ResourceManager.SolutionFolder))
+                Reload();
         }
 
         private async void Reload()


### PR DESCRIPTION
I've modified the program so that it can import an excel file into a new directory in the standalone version, and it creates all the .resx files corresponding to the contents of the excel, even if they don't exist.

It's fairly useful for me since i want the translations of my program to be standalone aswell and modifiable without having the source code of the application. Use case similar to https://github.com/dotnet/ResXResourceManager/issues/478 .
I "could" setup a directory with the proper files, but i think it's more robust if the program can create everything on import.

I haven't tested it very thoroughly, there probably are cases that break or ignore this behavior. I have only made it work when configured for multiple sheets, since the single-sheet mode uses different code and seems less functional (no error when it can't import, just silently does nothing).
The file creation only works with the "Global" scope (i assume it corresponds to the standalone mode ?) when a directory has been selected. It only creates the default language, since there already is a routine to add missing languages.

I think ideally there should be a popup which asks the user whether to create the missing file or not, but since the excel import code is far from the view i wasn't sure how to go about that.