### PR TITLE
Prefix #TODO to comments for each language entry

### DIFF
--- a/src/ResXManager.View/Visuals/TranslationItem.cs
+++ b/src/ResXManager.View/Visuals/TranslationItem.cs
@@ -61,8 +61,14 @@ namespace ResXManager.View.Visuals
             if (!_entry.CanEdit(_entry.NeutralLanguage.CultureKey))
                 return false;
 
-            _entry.Comments.SetValue(_entry.NeutralLanguage.CultureKey, commentPrefix + existingComment);
-
+            foreach (var languageKey in _entry.Languages)
+            {
+                if (!_entry.CanEdit(languageKey))
+                    continue;
+                if (languageKey == _entry.NeutralLanguage.CultureKey)
+                    continue;
+                _entry.Comments.SetValue(languageKey, commentPrefix + existingComment);
+            }
             return true;
         }
 


### PR DESCRIPTION
Prefix #TODO to comments for each language entry (other than the neutral language). This makes it easier to track which translations have been verified per language, as opposed to one comment for all languages.

(Related to #447)