### PR TITLE
Update configuration options for translation prefix

### DIFF
--- a/src/ResXManager.Infrastructure/ITranslationItem.cs
+++ b/src/ResXManager.Infrastructure/ITranslationItem.cs
@@ -12,6 +12,8 @@
 
         string? Translation { get; }
 
-        bool Apply(string? valuePrefix, string? commentPrefix);
+        bool UpdateTranslation(string? prefix);
+
+        bool UpdateComment(string? prefix, bool useNeutralLanguage, bool useTargetLanguage);
     }
 }

--- a/src/ResXManager.Model/Configuration.cs
+++ b/src/ResXManager.Model/Configuration.cs
@@ -16,6 +16,7 @@
     }
 
     [Flags]
+    [Obsolete("This enum value has been replaced with boolean flags on the Configuration")]
     public enum PrefixFieldType
     {
         [LocalizedDisplayName(StringResourceKey.PrefixFieldTypeValue)]
@@ -62,7 +63,14 @@
 
         public string? EffectiveTranslationPrefix { get; }
 
-        public PrefixFieldType PrefixFieldType { get; }
+        [Obsolete("This property is no longer used, and should not be relied upon to determine the current state. Replaced with boolean values instead")]
+        public PrefixFieldType? PrefixFieldType { get; }
+
+        public bool AddPrefixToValue { get; set; }
+
+        public bool AddPrefixToNeutralComment { get; set; }
+
+        public bool AddPrefixToTargetComment { get; set; }
 
         public ExcelExportMode ExcelExportMode { get; }
 
@@ -80,6 +88,7 @@
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             : base(tracer)
         {
+            MapOldPrefixValuesToNew();
         }
 
         [DefaultValue(CodeReferenceConfiguration.Default)]
@@ -119,8 +128,17 @@
 
         public string? EffectiveTranslationPrefix => PrefixTranslations ? TranslationPrefix : string.Empty;
 
-        [DefaultValue(PrefixFieldType.Value)]
-        public PrefixFieldType PrefixFieldType { get; set; }
+        [Obsolete]
+        public PrefixFieldType? PrefixFieldType { get; set; }
+
+        [DefaultValue(true)]
+        public bool AddPrefixToValue { get; set; }
+
+        [DefaultValue(true)]
+        public bool AddPrefixToNeutralComment { get; set; }
+
+        [DefaultValue(false)]
+        public bool AddPrefixToTargetComment { get; set; }
 
         [DefaultValue(default(ExcelExportMode))]
         public ExcelExportMode ExcelExportMode { get; set; }
@@ -140,5 +158,35 @@
         [DefaultValue(null)]
         [ForceGlobal]
         public string? TranslatorConfiguration { get; set; }
+
+        /// <summary>
+        /// Map deprecated property to current state (for backwards compatibility)
+        /// </summary>
+        private void MapOldPrefixValuesToNew()
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (PrefixFieldType == Model.PrefixFieldType.Value)
+            {
+                AddPrefixToNeutralComment = false;
+                AddPrefixToTargetComment = false;
+                AddPrefixToValue = true;
+            }
+            else if (PrefixFieldType == Model.PrefixFieldType.Comment)
+            {
+                AddPrefixToNeutralComment = true;
+                AddPrefixToTargetComment = false;
+                AddPrefixToNeutralComment = false;
+            }
+            else if (PrefixFieldType == Model.PrefixFieldType.Both)
+            {
+                AddPrefixToNeutralComment = true;
+                AddPrefixToTargetComment = false;
+                AddPrefixToNeutralComment = true;
+            }
+            PrefixFieldType = null;
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0612 // Type or member is obsolete
+        }
     }
 }

--- a/src/ResXManager.Scripting/Host.cs
+++ b/src/ResXManager.Scripting/Host.cs
@@ -196,7 +196,17 @@
 
         public string? EffectiveTranslationPrefix { get; set; }
 
-        public PrefixFieldType PrefixFieldType { get; set; }
+        [Obsolete]
+        public PrefixFieldType? PrefixFieldType { get; set; }
+
+        [DefaultValue(true)]
+        public bool AddPrefixToValue { get; set; }
+
+        [DefaultValue(true)]
+        public bool AddPrefixToNeutralComment { get; set; }
+
+        [DefaultValue(false)]
+        public bool AddPrefixToTargetComment { get; set; }
 
         public ExcelExportMode ExcelExportMode { get; set; }
 

--- a/src/ResXManager.View/Properties/Resources.Designer.cs
+++ b/src/ResXManager.View/Properties/Resources.Designer.cs
@@ -116,15 +116,6 @@ namespace ResXManager.View.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to "Append the translation prefix to"
-        /// </summary>
-        public static string AppendPrefixValueFieldTypeLabel {
-            get {
-                return ResourceManager.GetString("AppendPrefixValueFieldTypeLabel", resourceCulture) ?? string.Empty;
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to "Authentication"
         /// </summary>
         public static string Authentication {
@@ -313,6 +304,39 @@ namespace ResXManager.View.Properties {
         public static string Configuration_LoadSaveHeader {
             get {
                 return ResourceManager.GetString("Configuration_LoadSaveHeader", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to "Neutral Comment"
+        /// </summary>
+        public static string Configuration_PrefixNeutral
+        {
+            get
+            {
+                return ResourceManager.GetString("Configuration_PrefixNeutral", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to "Target Comment (per language)"
+        /// </summary>
+        public static string Configuration_PrefixTarget
+        {
+            get
+            {
+                return ResourceManager.GetString("Configuration_PrefixTarget", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to "Value"
+        /// </summary>
+        public static string Configuration_PrefixValue
+        {
+            get
+            {
+                return ResourceManager.GetString("Configuration_PrefixValue", resourceCulture) ?? string.Empty;
             }
         }
 
@@ -1152,10 +1176,6 @@ namespace ResXManager.View.Properties {
         /// </summary>
         AllLanguages,
         /// <summary>
-        ///   Looks up a localized string similar to Append the translation prefix to.
-        /// </summary>
-        AppendPrefixValueFieldTypeLabel,
-        /// <summary>
         ///   Looks up a localized string similar to Authentication.
         /// </summary>
         Authentication,
@@ -1242,6 +1262,18 @@ namespace ResXManager.View.Properties {
         ///   Looks up a localized string similar to Load &amp; Save.
         /// </summary>
         Configuration_LoadSaveHeader,
+        /// <summary>
+        ///   Looks up a localized string similar to Neutral Comment.
+        /// </summary>
+        Configuration_PrefixNeutral,
+        /// <summary>
+        ///   Looks up a localized string similar to Target Comment (per language).
+        /// </summary>
+        Configuration_PrefixTarget,
+        /// <summary>
+        ///   Looks up a localized string similar to Value.
+        /// </summary>
+        Configuration_PrefixValue,
         /// <summary>
         ///   Looks up a localized string similar to Consistency checks.
         /// </summary>

--- a/src/ResXManager.View/Properties/Resources.de.resx
+++ b/src/ResXManager.View/Properties/Resources.de.resx
@@ -473,7 +473,13 @@ Ihr ResXManager-Team.
   <data name="WarningUnsavedChanges" xml:space="preserve">
     <value>Es gibt noch ungesicherte Änderungen. Neu laden der Dateien wird alle Änderungen rückgängig machen. Wollen sie trotzdem fortfahren?</value>
   </data>
-  <data name="AppendPrefixValueFieldTypeLabel" xml:space="preserve">
-    <value>Hängen Sie das Übersetzungspräfix an an</value>
+  <data name="Configuration_PrefixValue" xml:space="preserve">
+    <value>Wert</value>
+  </data>
+  <data name="Configuration_PrefixNeutral" xml:space="preserve">
+    <value>Neutraler Kommentar</value>
+  </data>
+  <data name="Configuration_PrefixTarget" xml:space="preserve">
+    <value>Zielkommentar (pro Sprache)</value>
   </data>
 </root>

--- a/src/ResXManager.View/Properties/Resources.resx
+++ b/src/ResXManager.View/Properties/Resources.resx
@@ -483,7 +483,13 @@ Your ResXManager team.
   <data name="WarningUnsavedChanges" xml:space="preserve">
     <value>You have unsaved changes; reloading all resources will revert all your changes. Do you want to continue?</value>
   </data>
-  <data name="AppendPrefixValueFieldTypeLabel" xml:space="preserve">
-    <value>Append the translation prefix to</value>
+  <data name="Configuration_PrefixValue" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="Configuration_PrefixNeutral" xml:space="preserve">
+    <value>Neutral Comment</value>
+  </data>
+  <data name="Configuration_PrefixTarget" xml:space="preserve">
+    <value>Target Comment (per language)</value>
   </data>
 </root>

--- a/src/ResXManager.View/Properties/Resources.zh-Hans.resx
+++ b/src/ResXManager.View/Properties/Resources.zh-Hans.resx
@@ -450,9 +450,6 @@ ResXManager 团队
   <data name="WarningUnsavedChanges" xml:space="preserve">
     <value>你有未保存的更改，重新加载所有资源将放弃所有更改，你确定要继续吗？</value>
   </data>
-  <data name="AppendPrefixValueFieldTypeLabel" xml:space="preserve">
-    <value>将翻译前缀附加到</value>
-  </data>
   <data name="Configuration_XlifSupport" xml:space="preserve">
     <value>XLIF 支持</value>
   </data>
@@ -476,5 +473,14 @@ ResXManager 团队
   </data>
   <data name="WebProjectFileExport_Title" xml:space="preserve">
     <value>Web 项目文件导出</value>
+  </data>
+  <data name="Configuration_PrefixValue" xml:space="preserve">
+    <value>值</value>
+  </data>
+  <data name="Configuration_PrefixNeutral" xml:space="preserve">
+    <value>中立的评论</value>
+  </data>
+  <data name="Configuration_PrefixTarget" xml:space="preserve">
+    <value>目标评论（每种语言)</value>
   </data>
 </root>

--- a/src/ResXManager.View/Visuals/ConfigurationEditorView.xaml
+++ b/src/ResXManager.View/Visuals/ConfigurationEditorView.xaml
@@ -88,13 +88,37 @@
               </ComboBox.ItemTemplate>
             </ComboBox>
           </StackPanel>
-          <StackPanel Orientation="Horizontal">
-            <TextBlock Text="{x:Static properties:Resources.AppendPrefixValueFieldTypeLabel}" VerticalAlignment="Center" />
-            <Decorator Width="8" />
-            <ComboBox Width="175" ItemsSource="{Binding Source={x:Type model:PrefixFieldType}, Converter={x:Static toms:EnumToValuesConverter.Default}}"
-                     Style="{DynamicResource {x:Static styles:ResourceKeys.ComboBoxStyle}}" SelectedValue="{Binding Configuration.PrefixFieldType}"/>
-          </StackPanel>
         </StackPanel>
+      </GroupBox>
+
+      <Decorator Height="5" />
+
+      <GroupBox Header="Translations" Style="{StaticResource GroupStyle}">
+        <Grid Margin="10" KeyboardNavigation.TabNavigation="Local">
+          <StackPanel>
+            <StackPanel Orientation="Horizontal">
+              <CheckBox Content="{x:Static properties:Resources.TranslationsPrefixHeader}"
+                                IsChecked="{Binding Configuration.PrefixTranslations}"
+                                TabIndex="0"
+                                Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}" />
+              <TextBox Margin="4,0" IsReadOnly="True" Text="{Binding Configuration.TranslationPrefix}"/>
+            </StackPanel>
+            <StackPanel Margin="8,4" IsEnabled="{Binding Configuration.PrefixTranslations}">
+              <CheckBox IsChecked="{Binding Configuration.AddPrefixToValue}" TabIndex="0"
+                      Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}"
+                      Margin="4,2"
+                      Content="{x:Static properties:Resources.Configuration_PrefixValue}"/>
+              <CheckBox IsChecked="{Binding Configuration.AddPrefixToNeutralComment}" TabIndex="0"
+                      Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}"
+                        Margin="4,2"
+                      Content="{x:Static properties:Resources.Configuration_PrefixNeutral}"/>
+              <CheckBox IsChecked="{Binding Configuration.AddPrefixToTargetComment}" TabIndex="0"
+                      Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}"
+                        Margin="4,2"
+                      Content="{x:Static properties:Resources.Configuration_PrefixTarget}"/>
+            </StackPanel>
+          </StackPanel>
+        </Grid>
       </GroupBox>
 
       <Decorator Height="5" />

--- a/src/ResXManager.View/Visuals/TranslationsView.xaml
+++ b/src/ResXManager.View/Visuals/TranslationsView.xaml
@@ -107,14 +107,6 @@
                   <DockPanel DataContext="{Binding DataContext, RelativeSource={RelativeSource FindAncestor, AncestorType=DataGridCellsPanel}}" d:DataContext="{d:DesignInstance visuals:TranslationsViewModel}">
                     <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" Orientation="Horizontal">
                       <Decorator Width="20" />
-                      <CheckBox Content="{x:Static properties:Resources.TranslationsPrefixHeader}"
-                                IsChecked="{Binding Configuration.PrefixTranslations}"
-                                Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}" />
-                      <StackPanel Orientation="Horizontal" MinWidth="40">
-                        <TextBlock Text=" &quot;" VerticalAlignment="Center" />
-                        <TextBox Text="{Binding Configuration.TranslationPrefix}" BorderThickness="0" Padding="-1" Background="Transparent" Style="{DynamicResource {x:Static styles:ResourceKeys.TextBoxStyle}}" VerticalAlignment="Center" />
-                        <TextBlock Text="&quot;" VerticalAlignment="Center" />
-                      </StackPanel>
                     </StackPanel>
                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                       <TextBlock Text="{x:Static properties:Resources.Translations_Targets}" VerticalAlignment="Center" />

--- a/src/ResXManager.View/Visuals/TranslationsViewModel.cs
+++ b/src/ResXManager.View/Visuals/TranslationsViewModel.cs
@@ -123,13 +123,17 @@
         {
             var prefix = Configuration.EffectiveTranslationPrefix;
 
-            var valuePrefix = Configuration.PrefixFieldType.HasFlag(PrefixFieldType.Value) ? prefix : null;
-            var commentPrefix = Configuration.PrefixFieldType.HasFlag(PrefixFieldType.Comment) ? prefix : null;
-
             foreach (var item in items.Where(item => !string.IsNullOrEmpty(item.Translation)).ToArray())
             {
-                if (!item.Apply(valuePrefix, commentPrefix))
+                if (!item.UpdateTranslation(Configuration.AddPrefixToValue ? prefix : null))
                     break;
+
+                if (!item.UpdateComment(
+                    prefix,
+                    Configuration.AddPrefixToNeutralComment,
+                    Configuration.AddPrefixToTargetComment)
+                )
+                break;
 
                 Items.Remove(item);
             }


### PR DESCRIPTION
Allow configuring translation prefix settings to apply to the value, neutral comment, and/or target comment.