### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/src/ResXManager.Tests/ResXManager.Tests.csproj
+++ b/src/ResXManager.Tests/ResXManager.Tests.csproj
@@ -6,8 +6,8 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="Newtonsoft.Json" Version="[9.0.1]" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
     <PackageReference Include="TomsToolbox.Essentials" Version="2.8.10" />
     <PackageReference Include="TomsToolbox.Composition" Version="2.8.10" />
     <PackageReference Include="Verify.Xunit" Version="20.7.0" />

--- a/src/ResXManager.Tests/View/Tools/XlfSynchronizerTests.cs
+++ b/src/ResXManager.Tests/View/Tools/XlfSynchronizerTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace ResXManager.View.Tools.Tests
 {
-    using Moq;
+    using NSubstitute;
     using ResXManager.Infrastructure;
     using ResXManager.Model;
     using ResXManager.Tests;
@@ -24,8 +24,8 @@
 
                 FileHelper.CopyDirectory(@".\Resources\Files\GH0504", directory);
 
-                var configurationMock = new Mock<IConfiguration>();
-                var tracerMock = new Mock<ITracer>();
+                var configurationMock = Substitute.For<IConfiguration>();
+                var tracerMock = Substitute.For<ITracer>();
 
                 var projectFileName = Path.Combine(directory, "MyProject.resx");
                 var projectFrFileName = Path.Combine(directory, "MyProject.fr.resx");
@@ -37,7 +37,7 @@
                 // Synchronize several times to see if generates the same file
                 for (int i = 0; i < 6; i++)
                 {
-                    var resourceManager = new ResourceManager(configurationMock.Object, tracerMock.Object);
+                    var resourceManager = new ResourceManager(configurationMock, tracerMock);
 
                     var projectFiles = new[]
                     {
@@ -53,7 +53,7 @@
 
                     var xlfDocument = new XlfDocument(xlfDocumentPath);
 
-                    using (var xlfSynchronizer = new XlfSynchronizer(resourceManager, tracerMock.Object, configurationMock.Object))
+                    using (var xlfSynchronizer = new XlfSynchronizer(resourceManager, tracerMock, configurationMock))
                     {
                         xlfSynchronizer.UpdateEntityFromXlf(resourceEntity, xlfDocument.Files);
                     }


### PR DESCRIPTION
Replacing one mocking library with another.

Privacy issues were raised by https://github.com/moq/moq/issues/1372