### PR TITLE
Target .NET 7 in Standalone version

### DIFF
--- a/src/ResXManager.Infrastructure/ResXManager.Infrastructure.csproj
+++ b/src/ResXManager.Infrastructure/ResXManager.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Nullable.cs" Link="Nullable.cs" />

--- a/src/ResXManager.Infrastructure/ResXManager.Infrastructure.csproj
+++ b/src/ResXManager.Infrastructure/ResXManager.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Nullable.cs" Link="Nullable.cs" />

--- a/src/ResXManager.Model/ResXManager.Model.csproj
+++ b/src/ResXManager.Model/ResXManager.Model.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Nullable.cs" Link="Nullable.cs" />

--- a/src/ResXManager.Model/ResXManager.Model.csproj
+++ b/src/ResXManager.Model/ResXManager.Model.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Nullable.cs" Link="Nullable.cs" />

--- a/src/ResXManager.Translators/ResXManager.Translators.csproj
+++ b/src/ResXManager.Translators/ResXManager.Translators.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseWPF>true</UseWPF>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net7.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\Key.snk">

--- a/src/ResXManager.View/ResXManager.View.csproj
+++ b/src/ResXManager.View/ResXManager.View.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseWPF>true</UseWPF>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net7.0-windows</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Nullable.cs" Link="Nullable.cs" />

--- a/src/ResXManager/Properties/PublishProfiles/ClickOnce.pubxml
+++ b/src/ResXManager/Properties/PublishProfiles/ClickOnce.pubxml
@@ -31,10 +31,13 @@
     <UseApplicationTrust>false</UseApplicationTrust>
   </PropertyGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
-      <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
+    <BootstrapperPackage Include="Microsoft.NetCore.CoreRuntime.7.0.x64">
       <Install>true</Install>
+      <ProductName>.NET Runtime 7.0.13 (x64)</ProductName>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.NetCore.CoreRuntime.7.0.x86">
+      <Install>true</Install>
+      <ProductName>.NET Runtime 7.0.13 (x86)</ProductName>
     </BootstrapperPackage>
   </ItemGroup>
 </Project>

--- a/src/ResXManager/ResXManager.csproj
+++ b/src/ResXManager/ResXManager.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <WarningLevel>4</WarningLevel>
     <UseWindowsForms>true</UseWindowsForms>
@@ -27,13 +27,13 @@
     <PackageReference Include="ILMerge.Fody" PrivateAssets="all" Version="1.24.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" PrivateAssets="All" Version="1.1.5" />
     <PackageReference Include="PropertyChanged.Fody" PrivateAssets="all" Version="4.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="TomsToolbox.Composition.Ninject" Version="2.10.0" />
     <PackageReference Include="TomsToolbox.Wpf.Composition.AttributedModel" Version="2.10.0" />
     <PackageReference Include="TomsToolbox.Wpf.Styles" Version="2.10.0" />
-    <PackageReference Include="WindowsAPICodePack-Shell" PrivateAssets="All" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />


### PR DESCRIPTION
1. I have added target `net7.0` / `net7.0-windows` in all projects to be able to use an updated code base to .NET 7 with the benefit that you get from it in the standalone / ClickOne version.
2. I have changed the target of the ResXManager project from .NET Framework to .NET 7.
3. I have changed the ClickOnce profile dependencies so that it installs the .NET 7 runtime.
4. I have removed the `net472` target in Model / Infrastructure projects because with `netstandard2.0` it is already implicit: https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version
5. I have replaced `WindowsAPICodePack-Shell` with `Microsoft-WindowsAPICodePack-Shell` which is an updated fork, the previous one has compatibility problems being abandoned: https://www.nuget.org/packages/Microsoft-WindowsAPICodePack-Shell/#readme-body-tab

@tom-englert about your https://github.com/dotnet/ResXResourceManager/issues/598#issuecomment-1793785001 concern.

There have been 4-5 warnings generated when targeting .NET 7 but I think they are all fixable without having to do conditional code. I can solve them or if you want, compile it yourself from this branch and take a look at them to see what to do with each one.