### PR TITLE
Register blanks as changes

### DIFF
--- a/src/ResXManager.Model/EntryChange.cs
+++ b/src/ResXManager.Model/EntryChange.cs
@@ -23,4 +23,12 @@ namespace ResXManager.Model
 
         public string? OriginalText { get; }
     }
+
+    public static partial class EntryChangeExtensions
+    {
+        public static bool IsModified(this EntryChange entryChange)
+        {
+            return (entryChange.OriginalText != entryChange.Text) && !string.IsNullOrEmpty(entryChange.Text);
+        }
+    }
 }

--- a/src/ResXManager.Model/EntryChange.cs
+++ b/src/ResXManager.Model/EntryChange.cs
@@ -28,7 +28,11 @@ namespace ResXManager.Model
     {
         public static bool IsModified(this EntryChange entryChange)
         {
-            return (entryChange.OriginalText != entryChange.Text) && !string.IsNullOrEmpty(entryChange.Text);
+            if (entryChange.OriginalText == entryChange.Text)
+                return false;
+            if (entryChange.OriginalText == null && entryChange.Text != null)
+                return true;
+            return entryChange.OriginalText != entryChange.Text;
         }
     }
 }

--- a/src/ResXManager.Model/ResourceEntityExtensions.cs
+++ b/src/ResXManager.Model/ResourceEntityExtensions.cs
@@ -213,12 +213,14 @@
                         Culture = dataColumnHeaders[index].ExtractCulture(),
                         ColumnKind = dataColumnHeaders[index].GetColumnKind()
                     }))
-                .Where(mapping => mapping.Entry != null)
+                .Where(mapping => mapping.Entry != null);
+
+            var entries = mappings
                 .Select(mapping => new EntryChange(mapping.Entry!, mapping.Text, mapping.Culture, mapping.ColumnKind, mapping.Entry!.GetEntryData(mapping.Culture, mapping.ColumnKind)))
                 .ToArray();
 
-            var changes = mappings
-                .Where(mapping => (mapping.OriginalText != mapping.Text) && !string.IsNullOrEmpty(mapping.Text))
+            var changes = entries
+                .Where(entryChange => (entryChange.OriginalText != entryChange.Text) && !string.IsNullOrEmpty(entryChange.Text))
                 .ToArray();
 
             VerifyCultures(entity, changes.Select(c => c.Culture).Distinct());

--- a/src/ResXManager.Model/ResourceEntityExtensions.cs
+++ b/src/ResXManager.Model/ResourceEntityExtensions.cs
@@ -220,7 +220,7 @@
                 .ToArray();
 
             var changes = entries
-                .Where(entryChange => (entryChange.OriginalText != entryChange.Text) && !string.IsNullOrEmpty(entryChange.Text))
+                .Where(entryChange => entryChange.IsModified())
                 .ToArray();
 
             VerifyCultures(entity, changes.Select(c => c.Culture).Distinct());


### PR DESCRIPTION
If I export to an Excel sheet, make a change where a set a value to be an empty string, then import that Excel, the empty string should register as a change, but currently it does not.

The specific use case that I have for this is when I add a new string resource and translate it automatically, I put TODO in the comment as a way to indicate that the translation needs to be verified. After the translation is verified, our translators remove the comment in the Excel sheet. When we import the change, we need to update the comment to the blank value.