### PR TITLE
Add information to duplicate columns error to give better indication to user

### DIFF
--- a/src/ResXManager.Model/Properties/Resources.Designer.cs
+++ b/src/ResXManager.Model/Properties/Resources.Designer.cs
@@ -161,7 +161,7 @@ namespace ResXManager.Model.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to "Duplicate language in header."
+        ///   Looks up a localized string similar to "Duplicate language in headers {0} and {1} ('{2}')."
         /// </summary>
         public static string ImportDuplicateLanguageError {
             get {
@@ -617,7 +617,7 @@ namespace ResXManager.Model.Properties {
         /// </summary>
         ImportColumnMismatchError,
         /// <summary>
-        ///   Looks up a localized string similar to Duplicate language in header..
+        ///   Looks up a localized string similar to Duplicate language in headers {0} and {1} ('{2}')..
         /// </summary>
         ImportDuplicateLanguageError,
         /// <summary>

--- a/src/ResXManager.Model/Properties/Resources.de.resx
+++ b/src/ResXManager.Model/Properties/Resources.de.resx
@@ -146,7 +146,7 @@
     <value>Mindestens drei Spalten erwartet.</value>
   </data>
   <data name="ImportDuplicateLanguageError">
-    <value>Doppelte Sprache gefunden.</value>
+    <value>Doppelte Sprache in den Headern {0} und {1} ('{2}').</value>
   </data>
   <data name="ImportFailedError">
     <value>Import fehlgeschlagen. Es wurde nichts importiert.</value>

--- a/src/ResXManager.Model/Properties/Resources.resx
+++ b/src/ResXManager.Model/Properties/Resources.resx
@@ -150,7 +150,7 @@
     <value>At least three columns expected.</value>
   </data>
   <data name="ImportDuplicateLanguageError" xml:space="preserve">
-    <value>Duplicate language in header.</value>
+    <value>Duplicate language in headers {0} and {1} ('{2}').</value>
   </data>
   <data name="ImportFailedError" xml:space="preserve">
     <value>Import failed. Nothing has been imported.</value>

--- a/src/ResXManager.Model/Properties/Resources.zh-Hans.resx
+++ b/src/ResXManager.Model/Properties/Resources.zh-Hans.resx
@@ -147,7 +147,7 @@
     <value>预期至少三个列。</value>
   </data>
   <data name="ImportDuplicateLanguageError" xml:space="preserve">
-    <value>头部中有重复的语言。</value>
+    <value>标头 {0} 和 {1}（“{2}”）中的语言重复。</value>
   </data>
   <data name="ImportFailedError" xml:space="preserve">
     <value>导入失败，没有内容被导入。</value>

--- a/src/ResXManager.Model/ResourceEntityExtensions.cs
+++ b/src/ResXManager.Model/ResourceEntityExtensions.cs
@@ -7,6 +7,7 @@
 
     using ResXManager.Infrastructure;
     using ResXManager.Model.Properties;
+    using TomsToolbox.Essentials;
 
     public static partial class ResourceEntityExtensions
     {
@@ -197,8 +198,16 @@
 
             dataColumnCount = dataColumnHeaders.Length;
 
-            if (dataColumnHeaders.Distinct().Count() != dataColumnHeaders.Length)
-                throw new ImportException(Resources.ImportDuplicateLanguageError);
+            var uniqueHeaders = new HashSet<string>();
+            var currentIndex = 0;
+            foreach (var columnHeader in dataColumnHeaders)
+            {
+                if (!uniqueHeaders.Add(columnHeader))
+                {
+                    throw new ImportException(string.Format(CultureInfo.CurrentCulture, Resources.ImportDuplicateLanguageError, uniqueHeaders.IndexOf(columnHeader) + 1, currentIndex + 1, columnHeader));
+                }
+                currentIndex++;
+            }
 
             var mappings = table.Skip(1)
                 .Select(columns => new { Key = columns[0], TextColumns = columns.Skip(fixedColumnHeadersCount).Take(dataColumnCount).ToArray() })


### PR DESCRIPTION
When dealing with large number of columns, it can be difficult to determine exactly which column headers are duplicate, especially when the "duplicate" column headers are empty