### PR TITLE
Support newer OpenAI models

### DIFF
--- a/Documentation/Topics/Automatic-Translations.md
+++ b/Documentation/Topics/Automatic-Translations.md
@@ -17,20 +17,20 @@ All results can be reviewed by opening the combo box in the target column. The r
 
 #### Pros
 - Much more context aware
-- Higher quality translations
+- Higher quality translations, especially when fed with at least two different languages when translating to third/fourth/etc languages
 - Ability to use comments to guide the model
 - Better understanding of placeholders (such as {0}), seems to put them in better locations
 
 #### Cons
-- Much slower
+- Most models are slower, or much slower, than the other translation services
 - More expensive (depending on your token cost at Azure)
 
 #### Configuration
 - Add a new Azure OpenAI resource using the portal or CLI.
-- Deploy the "text-davinci-003" (completion based) or "gpt-3.5-turbo" (chat based) model.
+- Deploy the "gpt-3.5-turbo-instruct" (completion based) or "gpt-3.5-turbo"/"gpt-4-turbo" (chat based) model.
 - Copy the API key, URL to the endpoint and name of the deployment and model into the settings of the translator
 
 #### Addtional Settings
 - You can add a custom prompt to your request to improve the translation quality or behavior, e.g. "preserve the html tags in the results"
-- You can include the comments in your resources in the prompt, to guid the model with some additional hints about the context
+- You can include the comments in your resources in the prompt, to guide the model with additional hints about the context
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="ILMerge.Fody" Version="1.24.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.DeepDev.TokenizerLib" Version="[1.3.1]" />
+    <PackageVersion Include="Microsoft.DeepDev.TokenizerLib" Version="[1.3.3]" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK" Version="[15.0.1]" />


### PR DESCRIPTION
OpenAI has deprecated the "text-davinci-003" and replaced it with "gpt-3.5-turbo-instruct".
Added support for the instruct completions model, as well as the new "gpt-4-turbo" chat model.