### PR TITLE
Supports the use of other large language models compatible with the OpenAI API

### DIFF
--- a/Documentation/Topics/Automatic-Translations.md
+++ b/Documentation/Topics/Automatic-Translations.md
@@ -51,3 +51,4 @@ All results can be reviewed by opening the combo box in the target column. The r
 #### Addtional Settings
 - You can add a custom prompt to your request to improve the translation quality or behavior, e.g. "preserve the html tags in the results"
 - You can include the comments in your resources in the prompt, to guide the model with additional hints about the context
+- If you need to use other LLM services compatible with the OpenAI API (such as DeepSeek), you can modify the URL to the corresponding service address (for example: https://api.deepseek.com). Since the internal token counting function supports a limited number of models, you may need to disable token counting (uncheck Max Tokens) to use other models properly.

--- a/src/ResXManager.Translators/OpenAITranslatorConfiguration.xaml
+++ b/src/ResXManager.Translators/OpenAITranslatorConfiguration.xaml
@@ -12,6 +12,7 @@
     <StackPanel Orientation="Horizontal">
     <CheckBox Content="{x:Static properties:Resources.IncludeCommentsInPrompt}" IsChecked="{Binding IncludeCommentsInPrompt}" Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}" VerticalAlignment="Center" />
     <Decorator Width="20" />
+    <CheckBox Content="" IsChecked="{Binding CountTokens}" Style="{DynamicResource {x:Static styles:ResourceKeys.CheckBoxStyle}}" VerticalAlignment="Center" />
     <TextBlock Text="{x:Static properties:Resources.MaxTokens}" VerticalAlignment="Center" />
     <Decorator Width="5" />
     <TextBox Text="{Binding MaxTokens}" Style="{DynamicResource {x:Static styles:ResourceKeys.TextBoxStyle}}" />


### PR DESCRIPTION
1. Added the URL configuration item to support the use of other large model services; 
2. Aadded a switch to enable or disable token counting, in order to use models not in the `Microsoft.ML.TokenizersTiktokenTokenizer`'s model list.

Related to #681