### PR TITLE
#691 Updated DeepLTranslator with POST Requests and Authorization Hea…

### DIFF
--- a/src/ResXManager.Translators/DeepLTranslator.cs
+++ b/src/ResXManager.Translators/DeepLTranslator.cs
@@ -109,15 +109,6 @@ public class DeepLTranslator : TranslatorBase
                     model.Text[idx] = RemoveKeyboardShortcutIndicators(sourceItems[idx].Source);
                 }
 
-                // (Obsolete)
-                ////parameters.AddRange(new[]
-                ////{
-                ////    "target_lang", DeepLLangCode(targetCulture),
-                ////    "source_lang", DeepLLangCode(translationSession.SourceLanguage),
-                ////    "Authorization", ApiKey,
-                ////    "glossary_id", GlossaryId
-                ////});
-
                 var apiUrl = ApiUrl;
                 if (apiUrl.IsNullOrWhiteSpace())
                 {
@@ -125,15 +116,11 @@ public class DeepLTranslator : TranslatorBase
                 }
 
                 // Call the DeepL API (Obsolete)
-                ////var response = await GetHttpResponse<TranslationRootObject>(
-                ////    apiUrl,
-                ////    parameters,
-                ////    translationSession.CancellationToken).ConfigureAwait(false);
-
                 var response = await PostHttpResponse<TranslationRootObject>(
                     apiUrl,
                     model,
-                    translationSession.CancellationToken);
+                    translationSession.CancellationToken)
+                    .ConfigureAwait(false);
 
                 await translationSession.MainThread.StartNew(() =>
                 {

--- a/src/ResXManager.Translators/DeepLTranslator.cs
+++ b/src/ResXManager.Translators/DeepLTranslator.cs
@@ -98,15 +98,14 @@ public class DeepLTranslator : TranslatorBase
 
                 var model = new DeepLTranslationModel()
                 {
-                    Authorization = ApiKey,
                     GlossaryId = GlossaryId,
                     SourceLang = DeepLLangCode(translationSession.SourceLanguage),
                     TargetLang = DeepLLangCode(targetCulture),
                 };
 
-                for (var idx = 0; idx < sourceItems.Count; idx++)
+                foreach (var t in sourceItems)
                 {
-                    model.Text[idx] = RemoveKeyboardShortcutIndicators(sourceItems[idx].Source);
+                    model.Text.Add(RemoveKeyboardShortcutIndicators(t.Source));
                 }
 
                 var apiUrl = ApiUrl;
@@ -115,10 +114,11 @@ public class DeepLTranslator : TranslatorBase
                     apiUrl = "https://api.deepl.com/v2/translate";
                 }
 
-                // Call the DeepL API (Obsolete)
-                var response = await PostHttpResponse<TranslationRootObject>(
+                // Call the DeepL API
+                var response = await GetHttpResponse<TranslationRootObject>(
                     apiUrl,
                     model,
+                    ApiKey,
                     translationSession.CancellationToken)
                     .ConfigureAwait(false);
 
@@ -147,10 +147,11 @@ public class DeepLTranslator : TranslatorBase
     /// <typeparam name="T"></typeparam>
     /// <param name="baseUrl"></param>
     /// <param name="model"></param>
+    /// <param name="apiKey"></param>
     /// <param name="cancellationToken"></param>
     /// <returns>Returns the Translation result.</returns>
     /// <exception cref="InvalidOperationException"></exception>
-    private static async Task<T> PostHttpResponse<T>(string? baseUrl, DeepLTranslationModel model, CancellationToken cancellationToken)
+    private static async Task<T> GetHttpResponse<T>(string? baseUrl, DeepLTranslationModel model, string? apiKey, CancellationToken cancellationToken)
         where T : class
     {
         using var httpClient = new HttpClient();
@@ -158,25 +159,9 @@ public class DeepLTranslator : TranslatorBase
         var json = JsonConvert.SerializeObject(model);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("DeepL-Auth-Key", model.Authorization);
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("DeepL-Auth-Key", apiKey);
 
         var response = await httpClient.PostAsync(new Uri(baseUrl), content, cancellationToken).ConfigureAwait(false);
-
-        response.EnsureSuccessStatusCode();
-
-#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods => not available in NetFramework
-        using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        return JsonConverter<T>(stream) ?? throw new InvalidOperationException("Empty response.");
-    }
-
-    [Obsolete("As of March 14, 2025. Use PostHttpResponse. See https://developers.deepl.com/docs/resources/breaking-changes-change-notices/march-2025-deprecating-get-requests-to-translate-and-authenticating-with-auth_key#authenticate-with-an-http-header")]
-    private static async Task<T> GetHttpResponse<T>(string baseUrl, ICollection<string?> parameters, CancellationToken cancellationToken)
-        where T : class
-    {
-        var url = BuildUrl(baseUrl, parameters);
-
-        using var httpClient = new HttpClient();
-        var response = await httpClient.GetAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
 
         response.EnsureSuccessStatusCode();
 
@@ -214,7 +199,7 @@ public class DeepLTranslator : TranslatorBase
     private class DeepLTranslationModel
     {
         [DataMember(Name = "text")]
-        public string[] Text { get; set; } = [];
+        public List<string> Text { get; set; } = new();
 
         [DataMember(Name = "target_lang")]
         public string? TargetLang { get; set; }
@@ -224,33 +209,5 @@ public class DeepLTranslator : TranslatorBase
 
         [DataMember(Name = "glossary_id")]
         public string? GlossaryId { get; set; }
-
-        [IgnoreDataMember]
-        public string? Authorization { get; set; }
-    }
-
-
-    /// <summary>Builds the URL from a base, method name, and name/value paired parameters. All parameters are encoded.</summary>
-    /// <param name="url">The base URL.</param>
-    /// <param name="pairs">The name/value paired parameters.</param>
-    /// <returns>Resulting URL.</returns>
-    /// <exception cref="ArgumentException">There must be an even number of strings supplied for parameters.</exception>
-    private static string BuildUrl(string url, ICollection<string?> pairs)
-    {
-        if (pairs.Count % 2 != 0)
-            throw new ArgumentException("There must be an even number of strings supplied for parameters.");
-
-        var sb = new StringBuilder(url);
-        if (pairs.Count > 0)
-        {
-            sb.Append('?');
-            sb.Append(string.Join("&", pairs.Where((s, i) => i % 2 == 0).Zip(pairs.Where((s, i) => i % 2 == 1), Format)));
-        }
-        return sb.ToString();
-
-        static string Format(string? a, string? b)
-        {
-            return string.Concat(WebUtility.UrlEncode(a), "=", WebUtility.UrlEncode(b));
-        }
     }
 }


### PR DESCRIPTION
Possible fix of issue #691.

DeepL changed the API from GET to POST request. This should resolve the 404 response you get in the ResX Manager when translating with DeepL.

Tested it with ResX Manager and "https://api-free.deepl.com/v2/translate". Getting 200 Response with the correct translation.