### PR TITLE
Project filter

### DIFF
--- a/src/ResXManager.View/Behaviors/EntityFilter.cs
+++ b/src/ResXManager.View/Behaviors/EntityFilter.cs
@@ -1,4 +1,4 @@
-﻿namespace ResXManager.View.Behaviors;
+namespace ResXManager.View.Behaviors;
 
 using System;
 using System.Text.RegularExpressions;
@@ -8,6 +8,7 @@ using System.Windows.Controls;
 using Microsoft.Xaml.Behaviors;
 
 using ResXManager.Infrastructure;
+using ResXManager.Model;
 
 using Throttle;
 
@@ -26,21 +27,49 @@ public class EntityFilter : Behavior<ListBox>
     /// </summary>
     public static readonly DependencyProperty FilterTextProperty =
         DependencyProperty.Register(nameof(FilterText), typeof(string), typeof(EntityFilter),
-            new FrameworkPropertyMetadata(null, (sender, _) => ((EntityFilter)sender).FilterText_Changed()));
+            new FrameworkPropertyMetadata(null, (sender, _) => ((EntityFilter)sender).Filter_Changed()));
+
+    public string? ProjectFilter
+    {
+        get => (string)GetValue(ProjectFilterProperty);
+        set => SetValue(ProjectFilterProperty, value);
+    }
+    /// <summary>
+    /// Identifies the <see cref="ProjectFilter"/> dependency property
+    /// </summary>
+    public static readonly DependencyProperty ProjectFilterProperty =
+        DependencyProperty.Register(nameof(ProjectFilter), typeof(string), typeof(EntityFilter),
+            new FrameworkPropertyMetadata(null, (sender, _) => ((EntityFilter)sender).Filter_Changed()));
 
     [Throttled(typeof(Throttle), 300)]
-    private void FilterText_Changed()
+    private void Filter_Changed()
     {
         var listBox = AssociatedObject;
         if (listBox == null)
             return;
 
-        var value = FilterText;
+        var textFilter = BuildTextFilter(FilterText);
+        var projectFilter = ProjectFilter;
 
-        listBox.Items.Filter = BuildFilter(value);
+        if (textFilter == null && projectFilter == null)
+        {
+            listBox.Items.Filter = null;
+            return;
+        }
+
+        listBox.Items.Filter = item =>
+        {
+            if (projectFilter != null && item is ResourceEntity entity && !string.Equals(entity.ProjectName, projectFilter, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            if (textFilter != null && !textFilter(item))
+                return false;
+
+            return true;
+        };
     }
 
-    public static Predicate<object>? BuildFilter(string? value)
+    public static Predicate<object>? BuildTextFilter(string? value)
     {
         value = value?.Trim();
 
@@ -68,10 +97,13 @@ public class EntityFilter : Behavior<ListBox>
         return null;
     }
 
+    // Keep for backward compatibility with any external callers
+    public static Predicate<object>? BuildFilter(string? value) => BuildTextFilter(value);
+
     protected override void OnAttached()
     {
         base.OnAttached();
 
-        FilterText_Changed();
+        Filter_Changed();
     }
 }

--- a/src/ResXManager.View/Properties/Resources.Designer.cs
+++ b/src/ResXManager.View/Properties/Resources.Designer.cs
@@ -116,6 +116,24 @@ namespace ResXManager.View.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to "All Projects"
+        /// </summary>
+        public static string AllProjects {
+            get {
+                return ResourceManager.GetString("AllProjects", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to "Filter resource files by project"
+        /// </summary>
+        public static string ProjectFilterToolTip {
+            get {
+                return ResourceManager.GetString("ProjectFilterToolTip", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to "Append the translation prefix to"
         /// </summary>
         public static string AppendPrefixValueFieldTypeLabel {
@@ -1169,6 +1187,14 @@ namespace ResXManager.View.Properties {
         ///   Looks up a localized string similar to All languages.
         /// </summary>
         AllLanguages,
+        /// <summary>
+        ///   Looks up a localized string similar to All Projects.
+        /// </summary>
+        AllProjects,
+        /// <summary>
+        ///   Looks up a localized string similar to Filter resource files by project.
+        /// </summary>
+        ProjectFilterToolTip,
         /// <summary>
         ///   Looks up a localized string similar to Append the translation prefix to.
         /// </summary>

--- a/src/ResXManager.View/Properties/Resources.resx
+++ b/src/ResXManager.View/Properties/Resources.resx
@@ -459,6 +459,12 @@ Your ResXManager team.
   <data name="AllLanguages" xml:space="preserve">
     <value>All languages</value>
   </data>
+  <data name="AllProjects" xml:space="preserve">
+    <value>All Projects</value>
+  </data>
+  <data name="ProjectFilterToolTip" xml:space="preserve">
+    <value>Filter resource files by project</value>
+  </data>
   <data name="AllComments" xml:space="preserve">
     <value>All comments</value>
   </data>

--- a/src/ResXManager.View/Visuals/ResourceView.xaml
+++ b/src/ResXManager.View/Visuals/ResourceView.xaml
@@ -89,6 +89,8 @@
       <Grid.RowDefinitions>
         <RowDefinition Height="24" MinHeight="24" />
         <RowDefinition Height="4" />
+        <RowDefinition Height="Auto" />
+        <RowDefinition Height="4" />
         <RowDefinition Height="*" />
       </Grid.RowDefinitions>
       <DockPanel Grid.Row="0">
@@ -113,7 +115,31 @@
         </Border>
       </DockPanel>
 
-      <ListBox x:Name="ListBox" Grid.Row="2"
+      <ComboBox x:Name="ProjectFilterComboBox" Grid.Row="2"
+                ItemsSource="{Binding ProjectNames}"
+                SelectedItem="{Binding SelectedProject}"
+                IsEditable="False"
+                ToolTip="{x:Static properties:Resources.ProjectFilterToolTip}"
+                Style="{DynamicResource {x:Static styles:ResourceKeys.ComboBoxStyle}}">
+        <ComboBox.ItemTemplate>
+          <DataTemplate DataType="{x:Type visuals:ProjectFilterItem}">
+            <TextBlock>
+              <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                  <Setter Property="Text" Value="{Binding ProjectName}" />
+                  <Style.Triggers>
+                    <DataTrigger Binding="{Binding ProjectName}" Value="{x:Null}">
+                      <Setter Property="Text" Value="{x:Static properties:Resources.AllProjects}" />
+                    </DataTrigger>
+                  </Style.Triggers>
+                </Style>
+              </TextBlock.Style>
+            </TextBlock>
+          </DataTemplate>
+        </ComboBox.ItemTemplate>
+      </ComboBox>
+
+      <ListBox x:Name="ListBox" Grid.Row="4"
                ItemsSource="{Binding Source={StaticResource ResourceEntitiesSource}}"
                Padding="5,0" BorderThickness="1" SelectionMode="Extended"
                toms:MultiSelectorExtensions.SelectionBinding="{Binding SelectedEntities}"
@@ -165,7 +191,7 @@
           </ContextMenu>
         </ListBox.ContextMenu>
         <interactions:Interaction.Behaviors>
-          <behaviors:EntityFilter FilterText="{Binding Text, ElementName=EntityFilter}" />
+          <behaviors:EntityFilter FilterText="{Binding Text, ElementName=EntityFilter}" ProjectFilter="{Binding EffectiveProjectFilter}" />
           <behaviors:SelectAllBehavior x:Name="SelectAllBehavior" />
         </interactions:Interaction.Behaviors>
       </ListBox>

--- a/src/ResXManager.View/Visuals/ResourceViewModel.cs
+++ b/src/ResXManager.View/Visuals/ResourceViewModel.cs
@@ -18,6 +18,8 @@ using System.Windows.Threading;
 
 using DataGridExtensions;
 
+using PropertyChanged;
+
 using ResXManager.Infrastructure;
 using ResXManager.Model;
 using ResXManager.View.ColumnHeaders;
@@ -58,6 +60,7 @@ public sealed partial class ResourceViewModel : INotifyPropertyChanged, IDisposa
         ResourceTableEntries.CollectionChanged += (_, __) => ResourceTableEntries_CollectionChanged();
 
         resourceManager.LanguageChanged += ResourceManager_LanguageChanged;
+        resourceManager.ResourceEntities.CollectionChanged += (_, __) => UpdateProjectNames();
     }
 
     internal event EventHandler<ResourceTableEntryEventArgs>? ClearFiltersRequest;
@@ -69,6 +72,34 @@ public sealed partial class ResourceViewModel : INotifyPropertyChanged, IDisposa
     public ObservableCollection<ResourceEntity> SelectedEntities { get; } = [];
 
     public ObservableCollection<ResourceTableEntry> SelectedTableEntries { get; } = [];
+
+    public ObservableCollection<ProjectFilterItem> ProjectNames { get; } = [];
+
+    private void UpdateProjectNames()
+    {
+        var selectedProjectName = SelectedProject?.ProjectName;
+
+        var names = ResourceManager.ResourceEntities
+            .Select(e => e.ProjectName)
+            .Distinct()
+            .OrderBy(n => n, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        ProjectNames.Clear();
+        ProjectNames.Add(ProjectFilterItem.AllProjects);
+        foreach (var name in names)
+            ProjectNames.Add(new ProjectFilterItem(name));
+
+        // Restore selection if the project still exists, otherwise reset to All Projects
+        SelectedProject = (selectedProjectName != null
+            ? ProjectNames.FirstOrDefault(p => p.ProjectName == selectedProjectName)
+            : null) ?? ProjectNames[0];
+    }
+
+    public ProjectFilterItem? SelectedProject { get; set; }
+
+    [DependsOn(nameof(SelectedProject))]
+    public string? EffectiveProjectFilter => SelectedProject?.ProjectName;
 
     public bool IsLoading { get; private set; }
 
@@ -627,4 +658,11 @@ public sealed partial class ResourceViewModel : INotifyPropertyChanged, IDisposa
     {
         Interlocked.Exchange(ref _loadingCancellationTokenSource, null)?.Dispose();
     }
+}
+
+public sealed class ProjectFilterItem(string? projectName)
+{
+    public static readonly ProjectFilterItem AllProjects = new(null);
+
+    public string? ProjectName { get; } = projectName;
 }


### PR DESCRIPTION
Add a filter dropdown to only show Resource files for the selected project

- Currently you can click on a project header to quickly filter the visible string Resources down to the Resource files for that project, but this allows filtering the visible Resource files themselves, which can be helpful for large projects that each can have hundreds of Resource files.

#737