### PR TITLE
Perf - reduce allocations in CodeReferenceTracker file scanning

### DIFF
--- a/src/ResXManager.View/Tools/CodeReferenceTracker.cs
+++ b/src/ResXManager.View/Tools/CodeReferenceTracker.cs
@@ -258,15 +258,29 @@ public class CodeReferenceTracker : IService
                 _lines = _projectFile.ReadAllLines();
 
                 var index = 0;
+                var wordsInLine = new HashSet<string>();
 
                 foreach (var line in _lines)
                 {
-                    var wordsInLine = _splitWordsRegex.Split(line).ToHashSet();
+                    wordsInLine.Clear();
+                    foreach (var word in _splitWordsRegex.Split(line))
+                    {
+                        wordsInLine.Add(word);
+                    }
 
                     foreach (var key in keys)
                     {
                         var wordsInKey = key.Value;
-                        if (!wordsInKey.All(wordsInLine.Contains)) 
+                        var allContained = true;
+                        foreach (var word in wordsInKey)
+                        {
+                            if (!wordsInLine.Contains(word))
+                            {
+                                allContained = false;
+                                break;
+                            }
+                        }
+                        if (!allContained)
                             continue;
 
                         _keyLinesLookup.ForceValue(key.Key, _ => []).Add(index);


### PR DESCRIPTION
Noticed heavy allocations in the `FileInfo` constructor during some profiling, which has a hot inner loop that runs once per source line × resource key. Two patterns could cause unnecessary GC pressure:

1. `wordsInKey.All(wordsInLine.Contains)` - creates a new `Func<string, bool>` delegate and `SZGenericArrayEnumerator<string>` on every call.

2. `_splitWordsRegex.Split(line).ToHashSet()` - creates a new `HashSet<string>` with backing arrays per line, immediately discarded.

#### Changes

- Replace `All(wordsInLine.Contains)` with an inline `foreach` + early `break` - eliminates both the delegate and enumerator allocations
- Hoist the `HashSet<string>` outside the line loop and reuse via `Clear()`

should keep same behaviour - just fewer allocations.

#### Estimated impact

Allocations on this path drop from O(lines × keys) per file to O(lines), eliminating the dominant allocation sources. The reduction scales linearly with the number of source files in the solution and should help reduce GC pressure during code reference scanning