### PR TITLE
Google Translate - Format parameter change to default, HTML

### DIFF
--- a/src/ResXManager.Translators/GoogleTranslator.cs
+++ b/src/ResXManager.Translators/GoogleTranslator.cs
@@ -77,7 +77,7 @@ public class GoogleTranslator : TranslatorBase
                 parameters.AddRange(new[]
                 {
                     "target", GoogleLangCode(targetCulture),
-                    "format", "text",
+                    "format", "html",
                     "source", GoogleLangCode(translationSession.SourceLanguage),
                     "model", "nmt",
                     "key", ApiKey


### PR DESCRIPTION
Google Translate REST API (https://docs.cloud.google.com/translate/docs/reference/rest/v2/translate) says that default format is html.

Google Translator format argument is currently set to "text" which ends up frequently eating up the HTML tags within the translated text.

This should allow html contents to be translated properly without translator eating up the tags. I have been running a local patched copy and so far so good.