### PR TITLE
Temp fix for Google Translate - Bad Request (400)

### DIFF
--- a/src/ResXManager.Translators/GoogleTranslator.cs
+++ b/src/ResXManager.Translators/GoogleTranslator.cs
@@ -67,11 +67,19 @@ public class GoogleTranslator : TranslatorBase
                     break;
 
                 // Build out list of parameters
+                var payloadSoFar = 0;
                 var parameters = new List<string?>(30);
                 foreach (var item in sourceItems)
                 {
+                    var sourceText = RemoveKeyboardShortcutIndicators(item.Source);
+
+                    if (sourceText.Length + payloadSoFar > 4990)
+                        continue;
+
+                    payloadSoFar += sourceText.Length;
+
                     // ReSharper disable once PossibleNullReferenceException
-                    parameters.AddRange(new[] { "q", RemoveKeyboardShortcutIndicators(item.Source) });
+                    parameters.AddRange(new[] { "q", sourceText });
                 }
 
                 parameters.AddRange(new[]


### PR DESCRIPTION
Save the day / temporary fix for Google Bad Request (400). This will pull text till a query limit (5k) and will require multiple presses to "Start + Apply" if some text to be translated is too long. In next revision may do Take(1) till max(10, payload limit) for enumerator and let it do its thing. However another bigger issue remains: a single source can be bigger than 5k limit and splitting it up may degrade the nmt translation context causing worse translation on Google's end. This needs some research on proper splitting.

Tested and works on my projects (albeit with multiple Starts/Applies) with longer source text. Will come back to this soon to improve the process.